### PR TITLE
Add support back for version 233

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,6 @@ platformVersion = 2023.2.4
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins = org.jetbrains.plugins.textmate
 
-pluginSinceBuild = 232
+pluginSinceBuild = 233
 
 gradleVersion = 8.2


### PR DESCRIPTION
The pluginUntilBuild was removed but that removed support for 233 because the pluginSinceBuild was not updated.

Fixes #13