### PR TITLE
Add proper parsing for Go

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ platformVersion = 2023.2.4
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = org.jetbrains.plugins.textmate
+platformPlugins = org.jetbrains.plugins.textmate, org.jetbrains.plugins.go:232.10203.2
 
 pluginSinceBuild = 232
 

--- a/src/main/kotlin/com/templ/templ/file/TemplFileViewProvider.kt
+++ b/src/main/kotlin/com/templ/templ/file/TemplFileViewProvider.kt
@@ -1,5 +1,6 @@
 package com.templ.templ.file
 
+import com.goide.GoLanguage
 import com.intellij.lang.Language
 import com.intellij.lang.LanguageParserDefinitions
 import com.intellij.lang.html.HTMLLanguage
@@ -30,12 +31,18 @@ class TemplFileViewProvider(manager: PsiManager, virtualFile: VirtualFile, event
         }
     }
 
+    private val goLanguageType = object : TemplateDataElementType("Go inside Templ", GoLanguage.INSTANCE, TemplTypes.GO_ROOT_FRAGMENT, TemplLeafElementType("TEMPL_NOT_GO")) {
+        override fun getTemplateFileLanguage(viewProvider: TemplateLanguageFileViewProvider): Language {
+            return GoLanguage.INSTANCE
+        }
+    }
+
     override fun getBaseLanguage(): Language {
         return TemplLanguage
     }
 
     override fun getLanguages(): Set<Language> {
-        return setOf(baseLanguage, HTMLLanguage.INSTANCE)
+        return setOf(baseLanguage, HTMLLanguage.INSTANCE, GoLanguage.INSTANCE)
     }
 
     override fun getTemplateDataLanguage(): Language {
@@ -43,11 +50,15 @@ class TemplFileViewProvider(manager: PsiManager, virtualFile: VirtualFile, event
     }
 
     override fun createFile(lang: Language): PsiFile? {
-        if (lang === HTMLLanguage.INSTANCE) {
-            val file = LanguageParserDefinitions.INSTANCE.forLanguage(lang).createFile(this) as PsiFileImpl
-            file.contentElementType = htmlElementType
-            return file
-        } else if (lang === baseLanguage) {
+         if (lang === GoLanguage.INSTANCE) {
+             val file = LanguageParserDefinitions.INSTANCE.forLanguage(lang).createFile(this) as PsiFileImpl
+             file.contentElementType = goLanguageType
+             return file
+        } else if (lang === HTMLLanguage.INSTANCE) {
+             val file = LanguageParserDefinitions.INSTANCE.forLanguage(lang).createFile(this) as PsiFileImpl
+             file.contentElementType = htmlElementType
+             return file
+         } else if (lang === baseLanguage) {
             return LanguageParserDefinitions.INSTANCE.forLanguage(lang).createFile(this) as PsiFileImpl
         } else {
             return null

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,7 @@
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.ultimate</depends>
     <depends>org.jetbrains.plugins.textmate</depends>
+    <depends>org.jetbrains.plugins.go</depends>
     <extensions defaultExtensionNs="com.intellij">
         <fileType name="templ"
                   language="templ"


### PR DESCRIPTION
This adds Go as a template language, which should make regular go code outside `templ` blocks behave normally.