### PR TITLE
feat: resolve go path by using the bundled SDK (#37)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,12 +10,12 @@ pluginName = Templ
 pluginVersion = 0.0.14
 pluginGroup = com.templ
 
-platformType = IU
+platformType = GO
 platformVersion = 2023.2.4
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = org.jetbrains.plugins.textmate
+platformPlugins = org.jetbrains.plugins.textmate,org.jetbrains.plugins.go
 
 pluginSinceBuild = 232
 

--- a/src/main/kotlin/com/templ/templ/TemplLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/templ/templ/TemplLspServerSupportProvider.kt
@@ -1,5 +1,6 @@
 package com.templ.templ
 
+import com.goide.sdk.GoSdkService
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.PathEnvironmentVariableUtil
 import com.intellij.openapi.project.Project
@@ -33,6 +34,11 @@ private class TemplLspServerDescriptor(project: Project, val executable: File) :
         if (settings.http.isNotEmpty()) cmd.addParameter("-http=${settings.http}")
         if (settings.goplsRPCTrace) cmd.addParameter("-goplsRPCTrace=true")
         if (settings.pprof) cmd.addParameter("-pprof=true")
+
+        val goPath = GoSdkService.getInstance(project).getSdk(null).executable?.parent?.path
+        val currentPath = System.getenv("PATH").orEmpty()
+        goPath?.let { cmd.withEnvironment("PATH", "$it:$currentPath") }
+
         return cmd
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,7 @@
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.ultimate</depends>
     <depends>org.jetbrains.plugins.textmate</depends>
+    <depends>org.jetbrains.plugins.go</depends>
     <extensions defaultExtensionNs="com.intellij">
         <fileType name="templ"
                   language="templ"


### PR DESCRIPTION
This change is based on https://github.com/templ-go/templ-jetbrains/issues/37#issuecomment-2361783706 and adds the configured Go SDK  binary path in the inherited $PATH environment variable.

Note that:
* By adding the `org.jetbrains.plugins.go` dependency on the plugin.xml, the plugin will only load when the Go plugin is installed in the IDE. More info [here](https://plugins.jetbrains.com/docs/intellij/goland.html#targeting-ides-other-than-goland).
* I had to change the `intellij.type` to `GO` for two reasons:
  * The `org.jetbrains.plugins.go` plugin dependency could not be added to the `platformPlugins` list.
  * This change allows the plugin to be theoretically installed in IntelliJ Community Edition as well.
* I have only tested it in GoLand. This needs to be tested in other IDEs as well.