### PR TITLE
Add GoLand 2026.2 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle
@@ -102,7 +102,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle
@@ -149,7 +149,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
 
       # Remove old release drafts by using the curl request for the available releases with a draft flag
       - name: Remove Old Release Drafts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 25
+          java-version: 21
 
       # Setup Gradle
       - name: Setup Gradle
@@ -102,7 +102,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 25
+          java-version: 21
 
       # Setup Gradle
       - name: Setup Gradle
@@ -149,7 +149,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 25
+          java-version: 21
 
       # Remove old release drafts by using the curl request for the available releases with a draft flag
       - name: Remove Old Release Drafts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 25
+          java-version: 21
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ bin/
 ### Code generation dependencies automatically downloaded at code generation ###
 /src/main/grammar/idea-flex.skeleton
 /src/main/grammar/jflex-1.9.1.jar
+
+.intellijPlatform/

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.20" />
+    <option name="externalSystemId" value="Gradle" />
+    <option name="version" value="2.4.0" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" default="true" project-jdk-name="corretto-25" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="corretto-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_19" default="true" project-jdk-name="corretto-19" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" default="true" project-jdk-name="corretto-25" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Make plugin compatible with GoLand 2026.2 (#62) @nikitakuchur
+
 ## [0.0.20] - 2025-11-06
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 fun properties(key: String) = providers.gradleProperty(key)
 
@@ -74,11 +75,19 @@ intellijPlatform {
     }
 }
 dependencies {
+    testImplementation("junit:junit:4.13.2")
+
     intellijPlatform {
-        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+        create(
+            providers.gradleProperty("platformType"),
+            providers.gradleProperty("platformVersion")
+        )
 
+        bundledPlugins(
+            properties("platformBundledPlugins").map { it.split(',') }
+        )
 
-        bundledPlugins(properties("platformBundledPlugins").map { it.split(',') })
+        testFramework(TestFrameworkType.Platform)
     }
 }
 changelog {
@@ -93,12 +102,13 @@ tasks {
     }
     // Set the JVM compatibility versions
     withType<JavaCompile> {
-        sourceCompatibility = "17"
-        targetCompatibility = "17"
+        sourceCompatibility = "21"
+        targetCompatibility = "21"
     }
-    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions.jvmTarget = "17"
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile> {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+        }
     }
-
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,12 +11,10 @@ pluginVersion = 0.0.20
 pluginGroup = com.templ
 
 platformType = GO
-platformVersion = 2025.1
+platformVersion = 2026.2
 platformDownloadSources = true
 
-pluginSinceBuild = 251
-
-pluginVerifierIdeVersions = GO-2025.1
+pluginSinceBuild = 262
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 platformBundledPlugins = org.jetbrains.plugins.textmate,org.jetbrains.plugins.go

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,9 @@
 annotations = "24.0.1"
 
 # plugins
-kotlin = "2.1.20"
+kotlin = "2.4.0"
 changelog = "2.4.0"
-intelliJPlatform = "2.9.0"
+intelliJPlatform = "2.18.1"
 qodana = "2025.1.1"
 kover = "0.9.1"
 

--- a/src/main/kotlin/com/templ/templ/TemplLspIntegrationProvider.kt
+++ b/src/main/kotlin/com/templ/templ/TemplLspIntegrationProvider.kt
@@ -12,7 +12,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 
-class TemplLspServerSupportProvider : LspIntegrationProvider {
+class TemplLspIntegrationProvider : LspIntegrationProvider {
     override fun fileOpened(project: Project, file: VirtualFile, clientStarter: LspClientStarter) {
         val templConfigService = TemplSettings.getService(project)
         if (file.extension != "templ") return

--- a/src/main/kotlin/com/templ/templ/TemplLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/templ/templ/TemplLspServerSupportProvider.kt
@@ -5,26 +5,25 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.PathEnvironmentVariableUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.platform.lsp.api.LspServerSupportProvider
-import com.intellij.platform.lsp.api.LspServerSupportProvider.LspServerStarter
-import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
+import com.intellij.platform.lsp.api.LspIntegrationProvider
+import com.intellij.platform.lsp.api.LspIntegrationProvider.LspClientStarter
+import com.intellij.platform.lsp.api.ProjectWideLspClientDescriptor
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 
-class TemplLspServerSupportProvider : LspServerSupportProvider {
-    override fun fileOpened(project: Project, file: VirtualFile, serverStarter: LspServerStarter) {
-
+class TemplLspServerSupportProvider : LspIntegrationProvider {
+    override fun fileOpened(project: Project, file: VirtualFile, clientStarter: LspClientStarter) {
         val templConfigService = TemplSettings.getService(project)
         if (file.extension != "templ") return
         val executable = File(templConfigService.getTemplLspPath())
         if (!executable.exists()) return
-        serverStarter.ensureServerStarted(TemplLspServerDescriptor(project, executable))
+        clientStarter.ensureClientStarted(TemplLspClientDescriptor(project, executable))
     }
 }
 
-private class TemplLspServerDescriptor(project: Project, val executable: File) :
-    ProjectWideLspServerDescriptor(project, "templ") {
+private class TemplLspClientDescriptor(project: Project, val executable: File) :
+    ProjectWideLspClientDescriptor(project, "templ") {
     override fun isSupportedFile(file: VirtualFile) = file.extension == "templ"
     override fun createCommandLine(): GeneralCommandLine {
         val cmd = GeneralCommandLine(executable.absolutePath, "lsp")

--- a/src/main/kotlin/com/templ/templ/highlighting/TemplHighlightingLexer.kt
+++ b/src/main/kotlin/com/templ/templ/highlighting/TemplHighlightingLexer.kt
@@ -92,7 +92,7 @@ private fun getBundlePath(): Path {
     }
 }
 
-private val cachedTextMateLanguageDescriptor: TextMateLanguageDescriptor by lazy {
+private val textMateLanguageDescriptor: TextMateLanguageDescriptor by lazy {
     try {
         val plistReader = JsonOrXmlOrYamlPlistReader(JsonPlistReader(), XmlPlistReader(), null)
         val bundle = readTextMateBundle(
@@ -110,10 +110,8 @@ private val cachedTextMateLanguageDescriptor: TextMateLanguageDescriptor by lazy
     }
 }
 
-fun getTextMateLanguageDescriptor(): TextMateLanguageDescriptor = cachedTextMateLanguageDescriptor
-
 class TemplHighlightingLexer : TextMateHighlightingLexer(
-    getTextMateLanguageDescriptor(),
+    textMateLanguageDescriptor,
     TextMateSyntaxMatcherImpl(
         CaffeineCachingRegexProvider(RememberingLastMatchRegexFactory(JoniRegexFactory())),
         TextMateSelectorWeigherImpl().cachingSelectorWeigher(),

--- a/src/main/kotlin/com/templ/templ/highlighting/TemplHighlightingLexer.kt
+++ b/src/main/kotlin/com/templ/templ/highlighting/TemplHighlightingLexer.kt
@@ -92,7 +92,7 @@ private fun getBundlePath(): Path {
     }
 }
 
-fun getTextMateLanguageDescriptor(): TextMateLanguageDescriptor {
+private val cachedTextMateLanguageDescriptor: TextMateLanguageDescriptor by lazy {
     try {
         val plistReader = JsonOrXmlOrYamlPlistReader(JsonPlistReader(), XmlPlistReader(), null)
         val bundle = readTextMateBundle(
@@ -101,14 +101,16 @@ fun getTextMateLanguageDescriptor(): TextMateLanguageDescriptor {
             TextMateNioResourceReader(getBundlePath()),
         )
         val syntaxBuilder = TextMateSyntaxTableBuilder(TextMateConcurrentMapInterner())
-        for (grammar in bundle.readGrammars()) {
-            syntaxBuilder.addSyntax(grammar.plist.value)
+        for ((_, _, plist) in bundle.readGrammars()) {
+            syntaxBuilder.addSyntax(plist.value)
         }
-        return syntaxBuilder.build().getLanguageDescriptor("source.templ")
+        syntaxBuilder.build().getLanguageDescriptor("source.templ")
     } catch (ex: Exception) {
         throw RuntimeException(ex)
     }
 }
+
+fun getTextMateLanguageDescriptor(): TextMateLanguageDescriptor = cachedTextMateLanguageDescriptor
 
 class TemplHighlightingLexer : TextMateHighlightingLexer(
     getTextMateLanguageDescriptor(),

--- a/src/main/kotlin/com/templ/templ/highlighting/TemplHighlightingLexer.kt
+++ b/src/main/kotlin/com/templ/templ/highlighting/TemplHighlightingLexer.kt
@@ -1,18 +1,34 @@
 package com.templ.templ.highlighting
 
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
-import com.intellij.util.containers.Interner
-import com.templ.templ.TemplFileType
-import org.jetbrains.plugins.textmate.language.TextMateLanguageDescriptor
-import org.jetbrains.plugins.textmate.language.syntax.TextMateSyntaxTable
-import org.jetbrains.plugins.textmate.language.syntax.lexer.TextMateHighlightingLexer
-import java.io.*
-import java.nio.file.Path
-import java.util.zip.ZipInputStream
+import com.intellij.openapi.application.PathManager
 import com.intellij.psi.tree.IElementType
+import com.intellij.textmate.joni.JoniRegexFactory
+import com.templ.templ.TemplFileType
+import org.jetbrains.plugins.textmate.language.TextMateConcurrentMapInterner
+import org.jetbrains.plugins.textmate.language.TextMateLanguageDescriptor
+import org.jetbrains.plugins.textmate.bundles.TextMateNioResourceReader
 import org.jetbrains.plugins.textmate.bundles.readTextMateBundle
+import org.jetbrains.plugins.textmate.language.syntax.TextMateSyntaxTableBuilder
+import org.jetbrains.plugins.textmate.language.syntax.lexer.TextMateHighlightingLexer
 import org.jetbrains.plugins.textmate.language.syntax.lexer.TextMateElementType
+import org.jetbrains.plugins.textmate.language.syntax.lexer.TextMateSyntaxMatcherImpl
+import org.jetbrains.plugins.textmate.language.syntax.lexer.caching as cachingSyntaxMatcher
+import org.jetbrains.plugins.textmate.language.syntax.selector.TextMateSelectorWeigherImpl
+import org.jetbrains.plugins.textmate.language.syntax.selector.caching as cachingSelectorWeigher
+import org.jetbrains.plugins.textmate.plist.JsonOrXmlOrYamlPlistReader
+import org.jetbrains.plugins.textmate.plist.JsonPlistReader
+import org.jetbrains.plugins.textmate.plist.XmlPlistReader
+import org.jetbrains.plugins.textmate.regex.CaffeineCachingRegexProvider
+import org.jetbrains.plugins.textmate.regex.RememberingLastMatchRegexFactory
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.UncheckedIOException
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.HexFormat
+import java.util.zip.ZipInputStream
 
 
 private fun deleteFile(file: File) {
@@ -24,6 +40,7 @@ private fun deleteFile(file: File) {
     }
     file.delete()
 }
+
 @Throws(IOException::class)
 private fun extract(zip: ZipInputStream, target: File) {
     try {
@@ -50,39 +67,57 @@ private fun extract(zip: ZipInputStream, target: File) {
         zip.close()
     }
 }
+
 private fun getBundlePath(): Path {
     try {
-        val plugin = PluginManagerCore.getPlugin(PluginId.getId("com.templ.templ"))
-        val version = plugin?.version ?: "devel"
-        val bundleDirectory = File(plugin?.pluginPath.toString() + "/bundles/" + version)
+        val resource = TemplFileType::class.java.classLoader.getResource("tm-bundle.zip")
+            ?: error("TextMate bundle resource not found")
+        val bundleHash = resource.openStream().use { input ->
+            val digest = MessageDigest.getInstance("SHA-256").digest(input.readAllBytes())
+            HexFormat.of().formatHex(digest)
+        }
+        val bundleDirectory = PathManager.getSystemDir()
+            .resolve("templ")
+            .resolve("textmate")
+            .resolve(bundleHash)
+            .toFile()
         if (!bundleDirectory.exists()) {
-            deleteFile(bundleDirectory.getParentFile())
+            deleteFile(bundleDirectory.parentFile)
             bundleDirectory.mkdirs()
-            val resource = TemplFileType::class.java.classLoader.getResourceAsStream("tm-bundle.zip")
-
-            extract(ZipInputStream(resource!!), bundleDirectory)
+            extract(ZipInputStream(resource.openStream()), bundleDirectory)
         }
         return Path.of(bundleDirectory.path)
     } catch (ex: IOException) {
         throw UncheckedIOException(ex)
     }
 }
+
 fun getTextMateLanguageDescriptor(): TextMateLanguageDescriptor {
     try {
-        val bundle = readTextMateBundle(getBundlePath())
-        val syntax = TextMateSyntaxTable()
-        val interner = Interner.createWeakInterner<CharSequence>()
-        val grammars = bundle.readGrammars()
-        for (g in grammars) {
-            syntax.loadSyntax(g.plist.value, interner)
+        val plistReader = JsonOrXmlOrYamlPlistReader(JsonPlistReader(), XmlPlistReader(), null)
+        val bundle = readTextMateBundle(
+            "templ",
+            plistReader,
+            TextMateNioResourceReader(getBundlePath()),
+        )
+        val syntaxBuilder = TextMateSyntaxTableBuilder(TextMateConcurrentMapInterner())
+        for (grammar in bundle.readGrammars()) {
+            syntaxBuilder.addSyntax(grammar.plist.value)
         }
-        return TextMateLanguageDescriptor("source.templ", syntax.getSyntax("source.templ"))
+        return syntaxBuilder.build().getLanguageDescriptor("source.templ")
     } catch (ex: Exception) {
         throw RuntimeException(ex)
     }
 }
 
-class TemplHighlightingLexer : TextMateHighlightingLexer(getTextMateLanguageDescriptor(), 20000) {
+class TemplHighlightingLexer : TextMateHighlightingLexer(
+    getTextMateLanguageDescriptor(),
+    TextMateSyntaxMatcherImpl(
+        CaffeineCachingRegexProvider(RememberingLastMatchRegexFactory(JoniRegexFactory())),
+        TextMateSelectorWeigherImpl().cachingSelectorWeigher(),
+    ).cachingSyntaxMatcher(),
+    20000,
+) {
     override fun getTokenType(): IElementType? {
         val tt = super.getTokenType() ?: return null
         return TemplElementType((tt as TextMateElementType).scope)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,7 +27,7 @@
         <projectService serviceImplementation="com.templ.templ.TemplSettings"/>
         <projectConfigurable groupId="tools" instance="com.templ.templ.TemplConfigurable"/>
         <treeStructureProvider implementation="com.templ.templ.treestructure.TemplTreeStructureProvider"/>
-        <platform.lsp.serverSupportProvider implementation="com.templ.templ.TemplLspServerSupportProvider"/>
+        <platform.lsp.integrationProvider implementation="com.templ.templ.TemplLspServerSupportProvider"/>
         <spellchecker.support language="templ" implementationClass="com.intellij.spellchecker.tokenizer.SpellcheckingStrategy" />
         <spellchecker.bundledDictionaryProvider implementation="com.templ.templ.spellchecker.TemplBundledDictionaryProvider"/>
         <formattingService implementation="com.templ.templ.TemplFormatter"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,7 +27,7 @@
         <projectService serviceImplementation="com.templ.templ.TemplSettings"/>
         <projectConfigurable groupId="tools" instance="com.templ.templ.TemplConfigurable"/>
         <treeStructureProvider implementation="com.templ.templ.treestructure.TemplTreeStructureProvider"/>
-        <platform.lsp.integrationProvider implementation="com.templ.templ.TemplLspServerSupportProvider"/>
+        <platform.lsp.integrationProvider implementation="com.templ.templ.TemplLspIntegrationProvider"/>
         <spellchecker.support language="templ" implementationClass="com.intellij.spellchecker.tokenizer.SpellcheckingStrategy" />
         <spellchecker.bundledDictionaryProvider implementation="com.templ.templ.spellchecker.TemplBundledDictionaryProvider"/>
         <formattingService implementation="com.templ.templ.TemplFormatter"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,7 +5,7 @@
 
     <vendor url="https://templ.guide/">templ</vendor>
 
-    <idea-version since-build="232"/>
+    <idea-version since-build="262"/>
 
     <description>Support for the Templ Programming Language</description>
 


### PR DESCRIPTION
GoLand 2026.2 comes with IntelliJ Platform changes that affect the TextMate API used by the plugin for syntax highlighting. I updated the Kotlin and Java versions, migrated the TextMate and LSP integrations to the new APIs, and fixed the compatibility issues reported by `verifyPlugin`.